### PR TITLE
Reduce package size

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ conda activate met2go
 With the `met2go` environment activated, the path to MET (e.g. `grid_stat`) and METplus (e.g. `run_metplus.py`) executables is prepended to `PATH`, and the following environment variables are exported:
 
 - `METPLUS_PARM_BASE`: A directory containing<sup>*</sup> the contents of the `parm/` directory from the [METplus](https://dtcenter.org/community-code/metplus) distribution.
-- `MET_DATA`: A directory containing<sup>*</sup> the contents of the `data/` directory from the [MET](https://dtcenter.org/community-code/model-evaluation-tools-met) distribution.
+- `MET_DATA`: A directory containing various runtime data from the [MET](https://dtcenter.org/community-code/model-evaluation-tools-met) distribution.
 - `MET_PYTHON_EXE`: The path to the Python interpreter to be used by MET.
 
-\* The `METPLUS_PARM_BASE` and `MET_DATA` directories do not exist immediately after a `met2go` environment is created. To create and populate them, run `met2go-data` in the activated `met2go` environment.
+\* The `METPLUS_PARM_BASE` directory does not exist immediately after `met2go` is installed. To create and populate it, run `met2go-data` in the activated `met2go` environment. This requires write permissions on the conda-environment directory under which `met2go` is installed.
 
 In addition, the following scripts are available as executables on `PATH`:
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -50,6 +50,7 @@ met() {
     export MET_PYTHON_CC=$(python3-config --cflags)
     export MET_PYTHON_LD=$(python3-config --ldflags --embed)
     flags=(
+      --datarootdir=/dev/null # do not install data files
       --enable-grib2
       --enable-python
       --prefix=$PREFIX

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,7 +20,10 @@ bufr() {
 
 cleanup() {
   (
-    for path in $(find $PREFIX/lib -type f -name "*.a" | sort); do
+    rm -rv $PREFIX/include_*_DA
+    incfiles="$(find $PREFIX/include -type f)"
+    libfiles="$(find $PREFIX/lib -type f -name "*.a")"
+    for path in $incfiles $libfiles; do
       relative=$(echo $path | sed "s@^$PREFIX/@@")
       grep -q "^$relative$" $PREFIX/../prefix_files.txt || rm -v $path
     done

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,7 +19,11 @@ bufr() {
 }
 
 cleanup() {
-  find $PREFIX/lib -type f -name "*.a" | sort | xargs rm -v
+  local path relative
+  for path in $(find $PREFIX/lib -type f -name "*.a" | sort); do
+    relative=$(echo $path | sed "s@^$PREFIX/@@")
+    grep -q "^$relative$" $PREFIX/../prefix_files.txt || rm -v $path
+  done
 }
 
 datascript() {
@@ -54,13 +58,13 @@ met() {
     export MET_PYTHON_CC=$(python3-config --cflags)
     export MET_PYTHON_LD=$(python3-config --ldflags --embed)
     flags=(
+      --datarootdir=$PREFIX/../discard # do not package data
       --enable-grib2
       --enable-python
       --prefix=$PREFIX
     )
     ./configure ${flags[*]}
     make install
-    rm -vr $PREFIX/share/met # remove data
     mkdir -pv $PREFIX/etc/
   )
 }

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,6 +18,10 @@ bufr() {
   )
 }
 
+cleanup() {
+  find $PREFIX/lib -type f -name "*.a" | sort | xargs rm -v
+}
+
 datascript() {
   (
     metbase_url=$(jq -r .metbase $RECIPE_DIR/urls.json)
@@ -142,5 +146,6 @@ metcalcpy
 metdataio
 metplotpy
 datascript
+cleanup
 
 rsync -av $RECIPE_DIR/etc/ $PREFIX/etc/

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -54,13 +54,13 @@ met() {
     export MET_PYTHON_CC=$(python3-config --cflags)
     export MET_PYTHON_LD=$(python3-config --ldflags --embed)
     flags=(
-      --datarootdir=/dev/null # do not install data files
       --enable-grib2
       --enable-python
       --prefix=$PREFIX
     )
     ./configure ${flags[*]}
     make install
+    rm -vr $PREFIX/share/met # remove data
     mkdir -pv $PREFIX/etc/
   )
 }

--- a/recipe/datascript
+++ b/recipe/datascript
@@ -2,7 +2,6 @@
 
 set -eu
 
-url_metbase=<METBASE_URL> # replaced during package build
 url_metplus=<METPLUS_URL> # replaced during package build
 
 get() {
@@ -17,8 +16,5 @@ ver() {
   echo $1 | sed -E 's@^.*/v([0-9]+\.[0-9]+\.[0-9]+).*@\1@'
 }
 
-echo Installing MET data:
-get $url_metbase $MET_DATA MET-$(ver $url_metbase)/data/
-find $MET_DATA -type f -name "Makefile*" | sort | xargs rm -v
 echo Installing METplus data:
 get $url_metplus $METPLUS_PARM_BASE METplus-$(ver $url_metplus)/parm/

--- a/recipe/datascript
+++ b/recipe/datascript
@@ -17,5 +17,8 @@ ver() {
   echo $1 | sed -E 's@^.*/v([0-9]+\.[0-9]+\.[0-9]+).*@\1@'
 }
 
+echo Installing MET data:
 get $url_metbase $MET_DATA MET-$(ver $url_metbase)/data/
+find $MET_DATA -type f -name "Makefile*" | sort | xargs rm -v
+echo Installing METplus data:
 get $url_metplus $METPLUS_PARM_BASE METplus-$(ver $url_metplus)/parm/

--- a/recipe/etc/conda/activate.d/met-activate.sh
+++ b/recipe/etc/conda/activate.d/met-activate.sh
@@ -1,3 +1,3 @@
-export METPLUS_PARM_BASE=$CONDA_PREFIX/etc/metplus
-export MET_DATA=$CONDA_PREFIX/etc/met
+export METPLUS_PARM_BASE=$CONDA_PREFIX/share/metplus
+export MET_DATA=$CONDA_PREFIX/share/met
 export MET_PYTHON_EXE=$(which python)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     url: https://github.com/NOAA-EMC/NCEPLIBS-bufr/archive/refs/tags/bufr_v11.4.0.tar.gz
   - folder: met
     sha256: d99272c074c60d3011d0e47bede330ae8adc15f64d403480d8216815cbff7e7a
-    url: {{ urls["metbase"] }}
+    url: https://github.com/dtcenter/MET/archive/refs/tags/v11.0.3.tar.gz
   - folder: metcalcpy
     sha256: 41ad136683152265df80e27af49bac27e0d8d06606d1201aa1ffe215552640bf
     url: https://github.com/dtcenter/METcalcpy/archive/refs/tags/v3.0.0.tar.gz
@@ -52,6 +52,7 @@ requirements:
     - pip
     - pkgconfig
     - python
+    - rsync
     - setuptools
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}

--- a/recipe/urls.json
+++ b/recipe/urls.json
@@ -1,4 +1,3 @@
 {
-  "metbase": "https://github.com/dtcenter/MET/archive/refs/tags/v11.0.3.tar.gz",
   "metplus": "https://github.com/dtcenter/METplus/archive/refs/tags/v5.1.0.tar.gz"
 }


### PR DESCRIPTION
- A small optimization to exclude static libraries and include files, which are not useful for the applications `met2go` is targeting, from the package.
- MET already installs its data, so update `met2go-data` to only fetch METplus data and update docs accordingly.